### PR TITLE
Round off index value in calibration

### DIFF
--- a/src/components/tasks/Calibration.tsx
+++ b/src/components/tasks/Calibration.tsx
@@ -57,7 +57,8 @@ export default function Calibration(props: CalibrationProps) {
     const listenerId = moveAnimationValue.addListener((value) => {
       const { x, y } = value;
       if (onUpdate && curIndex !== x && x === y) {
-        curIndex = x;
+        // round to nearest integer because x may evaluate to imprecise float in some devices
+        curIndex = Math.round(x);
         /*
           Returns data containing a timestamp and the dot's updated (x,y) position relative to the canvas.
             (0, 0) represents the top left of the canvas.


### PR DESCRIPTION
This is a sort of patch because I have observed that some devices will crash during calibration because the `x` value in `curIndex = x` turns into an (im)precise float somehow. Eg. it's 4.99928750001709 instead of 5. Since curIndex is used to index an array, the float  makes it crash.

[ch18429]