### PR TITLE
Exclude example directory during 'prepare' stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The Senseye SDK provides direct integration into the Senseye API on both iOS and
 
 ```
 .
-+-- docs/         # See Documentation section of this README
-+-- example/      # Contains an example app that demos usage of the SDK
++-- docs/           # See Documentation section of this README
++-- example/        # Contains an example app that demos usage of the SDK
 +-- src/
-|   +-- api/         # Modules for interfacing with the Senseye API
-|   +-- components/  # Modules for serving Senseye frontend components
-+-- package.json     # Includes application dependencies, build utilities, and pre-commit hook directives. See contributing guide for more information on these directives
+|   +-- api/        # Modules for interfacing with the Senseye API
+|   +-- components/ # Modules for serving Senseye frontend components
++-- package.json    # Defines package dependencies, build utilities, and pre-commit hook directives. See contributing guide for more information on these directives
 ```
 
 ## Included Tasks
@@ -68,7 +68,7 @@ For local development, one of the dependencies is `babel-plugin-module-resolver`
       ```javascript
       import { SenseyeApiClient, Constants } from '@senseyeinc/react-native-senseye-sdk';
 
-      const apiClient = new SenseyeApiClient(Constants.API_HOST, Constants.API_BASE_PATH, <my_api_key>);
+      const apiClient = new SenseyeApiClient(Constants.API_HOST, Constants.API_BASE_PATH, 'my_api_key');
       ```
 
 3. Upload Session data.

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "targets": [
       "commonjs",
       "module",
-      "typescript"
+      ["typescript", { "project": "tsconfig.build.json" }]
     ]
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["example"]
+}


### PR DESCRIPTION
This solves an issue that occurs when other projects try to `yarn add` this SDK as a git dependency. Doing so runs this package's [lifecycle scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts) (e.g. `yarn prepare`), which included transpiling the example code and led to missing dependencies issues for the project trying to add it. This is undesired when packing/publishing the SDK, so we use `tsconfig.build.json`, but desired during the pre-commit hook, which defaults to `tsconfig.json`.