### PR TITLE
Hotfix/v0.4.1

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-senseye-sdk-example",
   "description": "Example app for react-native-senseye-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senseyeinc/react-native-senseye-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Senseye SDK provides direct integration into the Senseye API on both iOS and Android for React Native apps. The JavaScript API is simple and cross-platform. Ready to get started? Follow the instructions below.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Senseye SDK provides direct integration into the Senseye API on both iOS and Android for React Native apps. The JavaScript API is simple and cross-platform. Ready to get started? Follow the instructions below.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Fixes an issue that occurs for Typescript projects wanting to use this SDK's modules. When building their project with `tsc`, an error will occur complaining about a missing type declaration file for the SDK. This file is already being built and packaged as part of our release flow, but the path to it was not correctly defined in `package.json`.

e.g.
```
$ tsc --noEmit
src/screens/DemographicSurvey.tsx:14:33 - error TS7016: Could not find a declaration file for module '@senseyeinc/react-native-senseye-sdk'. '/Users/tam.nguyen/github/senseye-inc/senseye-react-native-app/node_modules/@senseyeinc/react-native-senseye-sdk/lib/commonjs/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/senseyeinc__react-native-senseye-sdk` if it exists or add a new declaration (.d.ts) file containing `declare module '@senseyeinc/react-native-senseye-sdk';`

14 import { Models, Surveys } from "@senseyeinc/react-native-senseye-sdk";
```